### PR TITLE
(vscode-gitlense) Add licenseUrl

### DIFF
--- a/manual/vscode-gitlens/vscode-gitlens.nuspec
+++ b/manual/vscode-gitlens/vscode-gitlens.nuspec
@@ -10,6 +10,7 @@
     <projectSourceUrl>https://github.com/eamodio/vscode-gitlens.git</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-gitlens</packageSourceUrl>
     <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/d2504b05cd9acc53d93c382c1727985004da4141/icons/vscode-gitlens.png</iconUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/eamodio.gitlens/license</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens</docsUrl>
     <bugTrackerUrl>https://github.com/eamodio/vscode-gitlens/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Add `licenseUrl` for `vscode-gitlense` package