### PR TITLE
(markdownlint-cli) Set correct min version of NodeJs

### DIFF
--- a/automatic/markdownlint-cli/markdownlint-cli.nuspec
+++ b/automatic/markdownlint-cli/markdownlint-cli.nuspec
@@ -19,7 +19,7 @@
     <releaseNotes>See https://github.com/igorshubovych/markdownlint-cli/releases</releaseNotes>
     <tags>nodejs node markdown linting markdownlint</tags>
     <dependencies>
-      <dependency id="nodejs" />
+      <dependency id="nodejs" version="0.12.0"/>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Set correct min version of Node.Js based on [project source code](https://github.com/igorshubovych/markdownlint-cli/blob/master/package.json#L10).