### PR TITLE
(gulp-cli) Set min version of NodeJs

### DIFF
--- a/automatic/gulp-cli/gulp-cli.nuspec
+++ b/automatic/gulp-cli/gulp-cli.nuspec
@@ -20,7 +20,7 @@
     <releaseNotes>See https://github.com/gulpjs/gulp-cli/blob/master/CHANGELOG.md</releaseNotes>
     <tags>nodejs node javascript web build gulp</tags>
     <dependencies>
-      <dependency id="nodejs" />
+      <dependency id="nodejs" version="0.10.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Set correct min version of Node.Js based on [project source code](https://github.com/gulpjs/gulp-cli/blob/master/package.json#L12).