### PR TITLE
Don't throw if icon could not be found

### DIFF
--- a/update_all.ps1
+++ b/update_all.ps1
@@ -96,7 +96,7 @@ $Options = [ordered]@{
     BeforeEach = {
         param($PackageName, $Options )
         $Options.ModulePaths | % { Import-Module $_ }
-        . $Options.UpdateIconScript $PackageName.ToLowerInvariant() -Quiet -ThrowErrorOnIconNotFound
+        . $Options.UpdateIconScript $PackageName.ToLowerInvariant() -Quiet
         if (Test-Path tools) { Expand-Aliases -Directory tools }
 
         $pattern = "^${PackageName}(?:\\(?<stream>[^:]+))?(?:\:(?<version>.+))?$"


### PR DESCRIPTION
Don't throw an exception if an icon could not be found as we don't have icons for all packages (e.g. markdownlint-cli)