### PR TITLE
Restrict npm package versions to Major.Minor.Build

### DIFF
--- a/automatic/gulp-cli/update.ps1
+++ b/automatic/gulp-cli/update.ps1
@@ -3,9 +3,12 @@ import-module au
 $releases = 'https://github.com/gulpjs/gulp-cli/releases'
 
 function global:au_SearchReplace {
+    $version = [Version]$Latest.Version
+    $packageVersion = [string]$version.Major + "." + $version.Minor + "." + $version.Build
+
     @{
         'tools\ChocolateyInstall.ps1' = @{
-            "(^[$]version\s*=\s*)('.*')" = "`$1'$($Latest.Version)'"
+            "(^[$]version\s*=\s*)('.*')" = "`$1'$($packageVersion)'"
         }
      }
 }

--- a/automatic/markdownlint-cli/update.ps1
+++ b/automatic/markdownlint-cli/update.ps1
@@ -3,9 +3,12 @@ import-module au
 $releases = 'https://github.com/igorshubovych/markdownlint-cli/releases'
 
 function global:au_SearchReplace {
+    $version = [Version]$Latest.Version
+    $packageVersion = [string]$version.Major + "." + $version.Minor + "." + $version.Build
+
     @{
         'tools\ChocolateyInstall.ps1' = @{
-            "(^[$]version\s*=\s*)('.*')" = "`$1'$($Latest.Version)'"
+            "(^[$]version\s*=\s*)('.*')" = "`$1'$($packageVersion)'"
         }
      }
 }


### PR DESCRIPTION
Restrict npm package versions to Major.Minor.Build to allow using package fix notation