### PR TITLE
(GH-46) Replace RawGit with jsDelivr

### DIFF
--- a/automatic/bower/bower.nuspec
+++ b/automatic/bower/bower.nuspec
@@ -4,13 +4,13 @@
   <metadata>
     <id>bower</id>
     <title>Bower</title>
-    <version>1.8.4</version>
+    <version>1.8.4.20181011</version>
     <authors>Twitter</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>http://bower.io/</projectUrl>
     <projectSourceUrl>https://github.com/bower/bower/</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/automatic/bower</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/9895f43909b7d6ff6978eda40e30e03fdcf84e29/icons/Bower.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@9895f43909b7d6ff6978eda40e30e03fdcf84e29/icons/Bower.png</iconUrl>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <docsUrl>https://bower.io/</docsUrl>
     <bugTrackerUrl>https://github.com/bower/bower/issues</bugTrackerUrl>

--- a/automatic/gulp-cli/gulp-cli.nuspec
+++ b/automatic/gulp-cli/gulp-cli.nuspec
@@ -4,13 +4,13 @@
   <metadata>
     <id>gulp-cli</id>
     <title>Command line interface for gulp</title>
-    <version>2.0.1</version>
+    <version>2.0.1.20181011</version>
     <authors>Fractal</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://github.com/gulpjs/gulp-cli</projectUrl>
     <projectSourceUrl>https://github.com/gulpjs/gulp-cli</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/automatic/gulp-cli</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/d632188d69029ca9ac53b8322de3f2641be1e59e/icons/gulp-cli.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@d632188d69029ca9ac53b8322de3f2641be1e59e/icons/gulp-cli.png</iconUrl>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <docsUrl>https://github.com/gulpjs/gulp-cli/tree/master/docs</docsUrl>
     <bugTrackerUrl>https://github.com/gulpjs/gulp-cli/issues</bugTrackerUrl>

--- a/automatic/markdownlint-cli/markdownlint-cli.nuspec
+++ b/automatic/markdownlint-cli/markdownlint-cli.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>markdownlint-cli</id>
     <title>MarkdownLint Command Line Interface</title>
-    <version>0.8.1</version>
+    <version>0.8.1.20181011</version>
     <authors>Igor Shubovych</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://github.com/igorshubovych/markdownlint-cli</projectUrl>

--- a/manual/dotnet4.6.2-deu/dotnet4.6.2-deu.nuspec
+++ b/manual/dotnet4.6.2-deu/dotnet4.6.2-deu.nuspec
@@ -3,12 +3,12 @@
   <metadata>
     <id>dotnet4.6.2-deu</id>
     <title>Microsoft .NET Framework 4.6.2 German Language Pack</title>
-    <version>4.6.1590.0</version>
+    <version>4.6.1590.20181011</version>
     <authors>Microsoft</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://www.microsoft.com/de-DE/download/details.aspx?id=53323</projectUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/dotnet4.6.2-deu</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/eca9d801fec67aa11df1af98be470d9ab601c5cf/icons/dotnet.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@eca9d801fec67aa11df1af98be470d9ab601c5cf/icons/dotnet.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The .NET Framework 4.6.2 Language Pack contains localized resources for supported languages.</summary>
     <description>

--- a/manual/vscode-cake/vscode-cake.nuspec
+++ b/manual/vscode-cake/vscode-cake.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vscode-cake</id>
     <title>Visual Studio Code Cake Extension</title>
-    <version>1.0.0.20180620</version>
+    <version>1.0.0.20181011</version>
     <authors>Cake Build</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=cake-build.cake-vscode</projectUrl>
     <projectSourceUrl>https://github.com/cake-build/cake-vscode</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-cake</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/19e7388f56f2faf2e2b7a270984d51e93ff8a1cb/icons/vscode-cake.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@19e7388f56f2faf2e2b7a270984d51e93ff8a1cb/icons/vscode-cake.png</iconUrl>
     <licenseUrl>https://marketplace.visualstudio.com/items/cake-build.cake-vscode/license</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=cake-build.cake-vscode</docsUrl>
     <bugTrackerUrl>https://github.com/cake-build/cake-vscode/issues</bugTrackerUrl>

--- a/manual/vscode-codespellchecker-german/vscode-codespellchecker-german.nuspec
+++ b/manual/vscode-codespellchecker-german/vscode-codespellchecker-german.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vscode-codespellchecker-german</id>
     <title>Visual Studio Code German Code Spell Checker Extension</title>
-    <version>1.0.0</version>
+    <version>1.0.0.20181011</version>
     <authors>Street Side Software</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker-german</projectUrl>
     <projectSourceUrl>https://github.com/Jason3S/vscode-cspell-dict-extensions</projectSourceUrl>
     <packageSourceUrl>hhttps://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-codespellchecker-german</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/549e229bcc6827f28fbc9f18fbd3b9ff3db607d7/icons/vscode-codespellchecker-german.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@549e229bcc6827f28fbc9f18fbd3b9ff3db607d7/icons/vscode-codespellchecker-german.png</iconUrl>
     <licenseUrl>hhttps://marketplace.visualstudio.com/items/streetsidesoftware.code-spell-checker/license</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker-german</docsUrl>
     <bugTrackerUrl>https://github.com/Jason3S/vscode-cspell-dict-extensions/issues</bugTrackerUrl>

--- a/manual/vscode-codespellchecker/vscode-codespellchecker.nuspec
+++ b/manual/vscode-codespellchecker/vscode-codespellchecker.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vscode-codespellchecker</id>
     <title>Visual Studio Code Code Spell Checker Extension</title>
-    <version>1.0.0</version>
+    <version>1.0.0.20181011</version>
     <authors>Street Side Software</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker</projectUrl>
     <projectSourceUrl>https://github.com/Jason-Rev/vscode-spell-checker</projectSourceUrl>
     <packageSourceUrl>hhttps://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-codespellchecker</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/c9a4773e0e332936f0b227eb9880bfcafbb1a2a7/icons/vscode-codespellchecker.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@c9a4773e0e332936f0b227eb9880bfcafbb1a2a7/icons/vscode-codespellchecker.png</iconUrl>
     <licenseUrl>hhttps://marketplace.visualstudio.com/items/streetsidesoftware.code-spell-checker/license</licenseUrl>
     <docsUrl>https://github.com/Jason-Rev/vscode-spell-checker/blob/master/client/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/Jason-Rev/vscode-spell-checker/issues</bugTrackerUrl>

--- a/manual/vscode-eslint/vscode-eslint.nuspec
+++ b/manual/vscode-eslint/vscode-eslint.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vscode-eslint</id>
     <title>Visual Studio Code ESLint Extension</title>
-    <version>1.0.0.20180620</version>
+    <version>1.0.0.20181011</version>
     <authors>Dirk Baeumer</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint</projectUrl>
     <projectSourceUrl>https://github.com/Microsoft/vscode-eslint</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-eslint</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/d8c9bacbea3fd9ad9824780608620b218b47e683/icons/vscode-eslint.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@d8c9bacbea3fd9ad9824780608620b218b47e683/icons/vscode-eslint.png</iconUrl>
     <licenseUrl>https://marketplace.visualstudio.com/items/dbaeumer.vscode-eslint/license</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint</docsUrl>
     <bugTrackerUrl>https://github.com/Microsoft/vscode-eslint/issues</bugTrackerUrl>

--- a/manual/vscode-gitlens/vscode-gitlens.nuspec
+++ b/manual/vscode-gitlens/vscode-gitlens.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vscode-gitlens</id>
     <title>Visual Studio Code Git Lens Extension</title>
-    <version>1.0.0.20180620</version>
+    <version>1.0.0.20181011</version>
     <authors>Eric Amodio</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens</projectUrl>
     <projectSourceUrl>https://github.com/eamodio/vscode-gitlens.git</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-gitlens</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/d2504b05cd9acc53d93c382c1727985004da4141/icons/vscode-gitlens.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@d2504b05cd9acc53d93c382c1727985004da4141/icons/vscode-gitlens.png</iconUrl>
     <licenseUrl>https://marketplace.visualstudio.com/items/eamodio.gitlens/license</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens</docsUrl>
     <bugTrackerUrl>https://github.com/eamodio/vscode-gitlens/issues</bugTrackerUrl>

--- a/manual/vscode-markdownlint/vscode-markdownlint.nuspec
+++ b/manual/vscode-markdownlint/vscode-markdownlint.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>vscode-markdownlint</id>
     <title>Visual Studio Code Markdownlint Extension</title>
-    <version>1.0.0.20180620</version>
+    <version>1.0.0.20181011</version>
     <authors>David Anson</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint</projectUrl>
     <projectSourceUrl>https://github.com/DavidAnson/vscode-markdownlint</projectSourceUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/manual/vscode-markdownlint</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/bbtsoftware/chocolatey-packages/4a055e434da1035a66c821c68869de8ea06bdd2f/icons/vscode-markdownlint.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@4a055e434da1035a66c821c68869de8ea06bdd2f/icons/vscode-markdownlint.png</iconUrl>
     <licenseUrl>https://marketplace.visualstudio.com/items/DavidAnson.vscode-markdownlint/license</licenseUrl>
     <docsUrl>https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint</docsUrl>
     <bugTrackerUrl>https://github.com/DavidAnson/vscode-markdownlint/issues</bugTrackerUrl>


### PR DESCRIPTION
Replace RawGit with jsDelivr as RawGit will shutdown its service

Fixes #46 