### PR TITLE
Update link to release notes

### DIFF
--- a/automatic/gulp-cli/gulp-cli.nuspec
+++ b/automatic/gulp-cli/gulp-cli.nuspec
@@ -23,7 +23,7 @@
 This package requires Node.js 0.10 or newer.
 You can install either the [nodejs](https://chocolatey.org/packages/nodejs) or [nodejs-lts](https://chocolatey.org/packages/nodejs-lts) package.
 ]]></description>
-    <releaseNotes>See https://github.com/gulpjs/gulp-cli/blob/master/CHANGELOG.md</releaseNotes>
+    <releaseNotes>See https://github.com/gulpjs/gulp-cli/releases</releaseNotes>
     <tags>nodejs node javascript web build gulp</tags>
   </metadata>
   <files>


### PR DESCRIPTION
`CHANGELOG.md` was deleted, see [here](https://github.com/gulpjs/gulp-cli/commit/39ea711bce7efd17aca69f2d7f41e89a95039643).