### PR TITLE
(dotnet*-deu) Remove 64-Bit variables

### DIFF
--- a/manual/dotnet4.6.2-deu/tools/chocolateyInstall.ps1
+++ b/manual/dotnet4.6.2-deu/tools/chocolateyInstall.ps1
@@ -10,9 +10,6 @@
     url           = "https://download.microsoft.com/download/C/3/D/C3DCF34C-6239-4301-9251-AA6BC675F7A7/NDP462-KB3151800-x86-x64-AllOS-DEU.exe"
     checksum      = '027A4A169DF195AF7F1386BD786BAAC64A2CF3CAA32F515656F41E7D6C00BEFF'
     checksumType  = 'sha256'
-    url64bit      = ""
-    checksum64    = ''
-    checksumType64= 'sha256'
   }
 
 Install-ChocolateyPackage @packageArgs

--- a/manual/dotnet4.7.2-deu/tools/chocolateyInstall.ps1
+++ b/manual/dotnet4.7.2-deu/tools/chocolateyInstall.ps1
@@ -22,9 +22,6 @@ $packageArgs = @{
     url           = "https://download.microsoft.com/download/b/9/5/b95136c0-58a0-48df-821a-d05319a86852/enu_NETFX/amd64_ndp472-kb4054530-x86-x64-allos-deu_exe/ndp472-kb4054530-x86-x64-allos-deu.exe"
     checksum      = '4A8EFFB5E202B937755F04A963F5B2EF9A53818DA84247250CA9F468FBD99244'
     checksumType  = 'sha256'
-    url64bit      = ""
-    checksum64    = ''
-    checksumType64= 'sha256'
   }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Remove 64-Bit variables as requested in review on community feed.