### PR TITLE
(ssis-vs2019) Use package metadata for links

### DIFF
--- a/automatic/ssis-vs2019/ssis-vs2019.nuspec
+++ b/automatic/ssis-vs2019/ssis-vs2019.nuspec
@@ -7,6 +7,7 @@
     <authors>Microsoft</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects</projectUrl>
+    <docsUrl>https://docs.microsoft.com/en-us/sql/ssdt/</docsUrl>
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/automatic/ssis-vs2019</packageSourceUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@74b0a3c4fe3e5ad5b896dd63f99a4edb346f8e21/icons/ssis-vs2019.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,17 +15,6 @@
     <description><![CDATA[This project may be used for building high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.
 
 Visit https://techcommunity.microsoft.com/t5/SQL-Server-Integration-Services/bg-p/SSIS for the latest information, tips, news, and announcements about SSIS directly from the product team.
-
-## Resources
-
-### Official Resources
-
-* [Project URL](https://marketplace.visualstudio.com/items?itemName=SSIS.SqlServerIntegrationServicesProjects)
-* [SSDT for Visual Studio](https://docs.microsoft.com/en-us/sql/ssdt/download-sql-server-data-tools-ssdt)
-
-### Interesting websites & blog posts
-
-* [Information, tips, news, and announcements about SSIS](https://techcommunity.microsoft.com/t5/SQL-Server-Integration-Services/bg-p/SSIS)
 
 ## Notes
 


### PR DESCRIPTION
Use package metadata instead of description for links