### PR TITLE
(dotnet4.6.2-deu) Change dependency to netfx-4.6.2

### DIFF
--- a/manual/dotnet4.6.2-deu/dotnet4.6.2-deu.nuspec
+++ b/manual/dotnet4.6.2-deu/dotnet4.6.2-deu.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>dotnet4.6.2-deu</id>
     <title>Microsoft .NET Framework 4.6.2 German Language Pack</title>
-    <version>4.6.1590.20181011</version>
+    <version>4.6.1590.20190918</version>
     <authors>Microsoft</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://www.microsoft.com/de-DE/download/details.aspx?id=53323</projectUrl>
@@ -14,13 +14,10 @@
     <description>
 The .NET Framework 4.6.2 Language Pack contains translated error messages and other UI text for languages other than English.
 You can install multiple language packs on one computer, each for a different language.
-
-You need to download and install the .NET Framework 4.6.2 prior to installing the language packs.
-You can find the Chocolatey package for .NET Framework 4.6.2 [here](https://chocolatey.org/packages/dotnet4.6.2).
     </description>
     <tags>microsoft .net .net-framework-4.6.2 language-pack admin</tags>
     <dependencies>
-      <dependency id="dotnet4.6.2" version="4.6" />
+      <dependency id="netfx-4.6.2" version="4.6.2.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
 Change dependency to netfx-4.6.2, which is the new recomended package for depdendencies on .NET 4.6.2

Fixes #82 