### PR TITLE
(ssis-vs2019) Make clear package is for Visual Studio 2019

### DIFF
--- a/automatic/ssis-vs2019/readme.md
+++ b/automatic/ssis-vs2019/readme.md
@@ -1,6 +1,6 @@
 # [<img src="https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@74b0a3c4fe3e5ad5b896dd63f99a4edb346f8e21/icons/ssis-vs2019.png" height="48" width="48" />Microsoft SQL Server Integration Services Projects](https://chocolatey.org/packages/ssis-vs2019)
 
-This project may be used for building high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.
+Extension for Visual Studio 2019 to build high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.
 
 Visit https://techcommunity.microsoft.com/t5/SQL-Server-Integration-Services/bg-p/SSIS for the latest information, tips, news, and announcements about SSIS directly from the product team.
 

--- a/automatic/ssis-vs2019/ssis-vs2019.nuspec
+++ b/automatic/ssis-vs2019/ssis-vs2019.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ssis-vs2019</id>
-    <title>Microsoft SQL Server Integration Services Projects</title>
+    <title>Microsoft SQL Server Integration Services Projects for Visual Studio 2019</title>
     <version>3.1</version>
     <authors>Microsoft</authors>
     <owners>BBT Software AG</owners>
@@ -11,8 +11,8 @@
     <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/automatic/ssis-vs2019</packageSourceUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/bbtsoftware/chocolatey-packages@74b0a3c4fe3e5ad5b896dd63f99a4edb346f8e21/icons/ssis-vs2019.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>This project may be used for building high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.</summary>
-    <description><![CDATA[This project may be used for building high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.
+    <summary>Extension for Visual Studio 2019 to build high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.</summary>
+    <description><![CDATA[Extension for Visual Studio 2019 to build high performance data integration and workflow solutions, including extraction, transformation, and loading (ETL) operations for data warehousing.
 
 Visit https://techcommunity.microsoft.com/t5/SQL-Server-Integration-Services/bg-p/SSIS for the latest information, tips, news, and announcements about SSIS directly from the product team.
 
@@ -20,7 +20,7 @@ Visit https://techcommunity.microsoft.com/t5/SQL-Server-Integration-Services/bg-
 
 This package has the following additional requirements:
 
-* Visual Studio core editor
+* Visual Studio 2019 core editor
 * SQL Server Data Tools
 * .NET Framework 4 targeting pack
 * .NET Framework 4.5 targeting pack


### PR DESCRIPTION
Make clear package is for Visual Studio 2019 as requested during review on chocolatey.org

Fixes #83 