### PR TITLE
(chocolatey-npm.extension) Add extension for installing NPM packages

### DIFF
--- a/extensions/chocolatey-npm.extension/CHANGELOG.md
+++ b/extensions/chocolatey-npm.extension/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 1.0.0
+
+- Added `Install-NpmPackage`
+- Added `Uninstall-NpmPackage`

--- a/extensions/chocolatey-npm.extension/chocolatey-npm.extension.nuspec
+++ b/extensions/chocolatey-npm.extension/chocolatey-npm.extension.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>chocolatey-npm.extension</id>
+    <version>1.0.0</version>
+    <title>Chocolatey NPM servicing extension</title>
+    <summary>Helper functions useful for developing packages for installing NPM packages.</summary>
+    <authors>BBT Software AG</authors>
+    <owners>bbtsoftware, pascalberger</owners>
+    <description>
+This package provides helper functions useful for developing packages for installing NPM packages.
+These functions may be used in Chocolatey install/uninstall scripts by declaring this package a dependency in your package's nuspec.
+    </description>
+    <tags>chocolatey extension npm admin</tags>
+    <projectUrl>https://github.com/bbtsoftware/chocolatey-packages</projectUrl>
+    <copyright>Copyright © BBT Software AG and contributors</copyright>
+    <licenseUrl>https://github.com/bbtsoftware/chocolatey-packages/blob/master/LICENSE.md</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/bbtsoftware/chocolatey-packages</projectSourceUrl>
+    <packageSourceUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/extensions/chocolatey-npm.extension</packageSourceUrl>
+    <docsUrl>https://github.com/bbtsoftware/chocolatey-packages/tree/master/extensions/chocolatey-npm.extension/README.md</docsUrl>
+    <bugTrackerUrl>https://github.com/bbtsoftware/chocolatey-packages/issues</bugTrackerUrl>
+    <releaseNotes>https://github.com/bbtsoftware/chocolatey-packages/tree/master/extensions/chocolatey-npm.extension/CHANGELOG.md</releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.5.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="extensions\**" target="extensions" />
+  </files>
+</package>

--- a/extensions/chocolatey-npm.extension/extensions/Install-NpmPackage.ps1
+++ b/extensions/chocolatey-npm.extension/extensions/Install-NpmPackage.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    Installs an NPM package gloabl for the current user.
+
+.DESCRIPTION
+    Installs an NPM package gloabl for the current user.
+
+    Requires that NodeJS is installed, otherwise an error is shown.
+
+    Supports installing packages for the user which initiated the process when running in background mode.
+
+.EXAMPLE
+    PS> Install-NpmPackage markdownlint
+
+    Installs the 'markdownlint' package
+
+.EXAMPLE
+    PS> Install-NpmPackage markdownlint@0.23.2
+
+    Installs version 0.23.2 of the 'markdownlint' package.
+#>
+function Install-NpmPackage {
+    [CmdletBinding()]
+    param(
+        # Scope, name and version of the package to install
+        [Parameter(Mandatory = $true)]
+        [string]$package
+    )
+
+    if (-Not (Get-Command "node" -errorAction SilentlyContinue)) {
+        $packageName = $env:ChocolateyPackageName
+        Write-Error "$packageName requires Node.js to be installed. To install with Chocolatey, use either of the commands below:"
+        Write-Error "  choco install nodejs"
+        Write-Error "  choco install nodejs-lts"
+        throw "Node.js not found"
+    } else {
+        $user = $env:USER_CONTEXT
+        if ($user) {
+            Write-Host "Detected running in background mode"
+            Write-Host "Installing for user '$user'"
+
+            $profilesDirectory = (Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\ProfileList" -Name "ProfilesDirectory").ProfilesDirectory
+            $userNpmDirectory = "$profilesDirectory\$user\AppData\Roaming\npm"
+
+            $currentPrefix = npm prefix -g
+            try {
+                # Set folder for global packages to user folder of user which initiated the installation.
+                npm config set prefix $userNpmDirectory
+
+                npm install -g $package
+            }
+            finally {
+                npm config set prefix $currentPrefix
+            }
+
+        }
+        else {
+            npm install -g $package
+        }
+    }
+}

--- a/extensions/chocolatey-npm.extension/extensions/Uninstall-NpmPackage.ps1
+++ b/extensions/chocolatey-npm.extension/extensions/Uninstall-NpmPackage.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+    Uninstalls an NPM package.
+
+.DESCRIPTION
+    Uninstalls an NPM package.
+
+    Supports uninstalling packages for the user which initiated the process when running in background mode.
+
+.EXAMPLE
+    PS> Uninstall-NpmPackage markdownlint-cli
+
+    Uninstalls the 'markdownlint-cli' package.
+#>
+function Uninstall-NpmPackage {
+    [CmdletBinding()]
+    param(
+        # Name of the package to uninstall
+        [Parameter(Mandatory = $true)]
+        [string]$package
+    )
+
+    $user = $env:USER_CONTEXT
+    if ($user) {
+        Write-Host "Detected running in background mode"
+        Write-Host "Uninstalling for user '$user'"
+
+        $profilesDirectory = (Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\ProfileList" -Name "ProfilesDirectory").ProfilesDirectory
+        $userNpmDirectory = "$profilesDirectory\$user\AppData\Roaming\npm"
+
+        $currentPrefix = npm prefix -g
+        try {
+            # Set folder for global packages to user folder of user which initiated the uninstallation.
+            npm config set prefix $userNpmDirectory
+
+            npm uninstall -g $package
+        }
+        finally {
+            npm config set prefix $currentPrefix
+        }
+
+    }
+    else {
+        npm uninstall -g $package
+    }
+}

--- a/extensions/chocolatey-npm.extension/extensions/chocolatey-npm.psm1
+++ b/extensions/chocolatey-npm.extension/extensions/chocolatey-npm.psm1
@@ -1,0 +1,11 @@
+# Export functions that start with capital letter, others are private
+# Include file names that start with capital letters, ignore others
+$ScriptRoot = Split-Path $MyInvocation.MyCommand.Definition
+
+$pre = Get-ChildItem Function:\*
+Get-ChildItem "$ScriptRoot\*.ps1" | Where-Object { $_.Name -cmatch '^[A-Z]+' } | ForEach-Object { . $_  }
+$post = Get-ChildItem Function:\*
+$funcs = Compare-Object $pre $post | Select-Object -Expand InputObject | Select-Object -Expand Name
+$funcs | Where-Object { $_ -cmatch '^[A-Z]+'} | ForEach-Object { Export-ModuleMember -Function $_ }
+
+#Export-ModuleMember -Alias *

--- a/extensions/extensions.psm1
+++ b/extensions/extensions.psm1
@@ -1,0 +1,7 @@
+﻿# This file is just to simplify importing of extensions for use in AU update scripts
+
+$modules = ls "$PSSCriptRoot/*.psm1" -Recurse -Exclude "extensions.psm1"
+
+foreach ($module in $modules) {
+  import-module $module.FullName
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
This is a new extension which allows to install and uninstall NPM packages.

## Motivation and Context
There exist several Chocolatey packages which are installing NPM packages. Installing NPM packages, even global, will always install into user profile, which leads to issues with a system wide package manager like Chocolatey.
This extension allows to work around some of them. It checks if NodeJs has been installed and if installing using background mode will install into user profile of user which initiated the process instead of installing into the profile of the user under which the Chocolatey service is running.

## How Has this Been Tested?
Tested locally, with a modified version of the markdownlint-cli package on a machine where Chocolatey was configured to run with background mode and on a machine where Chocolatey was configured to run without background mode.
