### PR TITLE
Bump version number of markdownlint-cli to match version published on chocolatey.org

### DIFF
--- a/automatic/markdownlint-cli/markdownlint-cli.nuspec
+++ b/automatic/markdownlint-cli/markdownlint-cli.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>markdownlint-cli</id>
     <title>MarkdownLint Command Line Interface</title>
-    <version>0.23.2</version>
+    <version>0.25.0</version>
     <authors>Igor Shubovych</authors>
     <owners>BBT Software AG</owners>
     <projectUrl>https://github.com/igorshubovych/markdownlint-cli</projectUrl>


### PR DESCRIPTION
Bump version number of markdownlint-cli to match version published on chocolatey.org