### PR TITLE
(markdownlint-cli) Fix update of package

### DIFF
--- a/automatic/markdownlint-cli/update.ps1
+++ b/automatic/markdownlint-cli/update.ps1
@@ -1,6 +1,8 @@
 import-module au
+import-module PowerShellForGitHub
 
-$releases = 'https://github.com/igorshubovych/markdownlint-cli/releases'
+$repoOwner = 'igorshubovych'
+$repoName = 'markdownlint-cli'
 
 function global:au_SearchReplace {
     $version = [Version]$Latest.Version
@@ -14,17 +16,15 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $release = Get-GitHubRelease -OwnerName $repoOwner -RepositoryName $repoName -Latest
+    $version = $release.tag_name
+    if ($version.StartsWith('v')) {
+      $version = $version.Substring(1)
+    }
 
-    #v0.8.1.zip
-    $re  = "(.*).zip"
-    $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
-    $file = $url -split 'v' | Select-Object -last 1
-
-    $version = [IO.Path]::GetFileNameWithoutExtension($file)
-
-    $Latest = @{ Version = $version }
-    return $Latest
+    @{
+      Version   = $version
+    }
 }
 
 update -ChecksumFor none

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,9 @@ jobs:
       . "$Env:TEMP/au/scripts/Install-AU.ps1" $Env:au_version
     displayName: 'Clone AU'
   - powershell: |
+      Install-Module PowerShellForGitHub -Force
+    displayName: 'Install required modules'
+  - powershell: |
       "Build info"
       '  {0,-20} {1}' -f 'Build reason:', $Env:BUILD_REASON
     displayName: 'Show build information'


### PR DESCRIPTION
Fixes updating of markdownlint-cli package. 

Since GitHub has limited possibilities how to read release information, this PR adds the PowerShellForGitHub module to read release information. 